### PR TITLE
Switch Hawaii places to islands

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,8 +132,8 @@ const annualPosts = posts.filter((post) => hasTag(post, "annual"));
               <li>
                 hawaii
                 <ul>
-                  <li>honolulu</li>
-                  <li>kahului</li>
+                  <li>oahu</li>
+                  <li>maui</li>
                 </ul>
               </li>
               <li>


### PR DESCRIPTION
## Summary
- update the Hawaii entries under `/places` to represent islands instead of cities
- replace `honolulu` with `oahu`
- replace `kahului` with `maui`